### PR TITLE
Fixed the `loadImGuiSupport` call which was hard-coded to "imgui_gl_loader.dll" for all platforms

### DIFF
--- a/generator/generator.d
+++ b/generator/generator.d
@@ -382,7 +382,7 @@ bool loadImGuiSupport()
 
 bool loadImGuiSupport(const(char)* libName)
 {
-    lib = load("imgui_gl_loader.dll");
+    lib = load(libName);
     if(lib == invalidHandle) {
         return false;
     }

--- a/source/bindbc/imgui/dynload.d
+++ b/source/bindbc/imgui/dynload.d
@@ -50,7 +50,7 @@ bool loadImGuiSupport()
 
 bool loadImGuiSupport(const(char)* libName)
 {
-    lib = load("imgui_gl_loader.dll");
+    lib = load(libName);
     if(lib == invalidHandle) {
         return false;
     }


### PR DESCRIPTION
This was hardcoded to `imgui_gl_loader.dll` despite it checking which platform it was on